### PR TITLE
Fix connection bug in Validator

### DIFF
--- a/Example_ActiveMQCamel/Validator/src/de/tuberlin/cit/vs/Validator.java
+++ b/Example_ActiveMQCamel/Validator/src/de/tuberlin/cit/vs/Validator.java
@@ -8,7 +8,12 @@ import java.io.IOException;
 public class Validator {
     public static void main(String[] args) {
         try {
-            ActiveMQConnectionFactory conFactory = new ActiveMQConnectionFactory();
+            // Explicitly specify the broker URL to avoid relying on the
+            // implementation's default value which may differ across
+            // ActiveMQ versions. Without this the application might fail
+            // to connect to the embedded broker started by IntegrationApp.
+            ActiveMQConnectionFactory conFactory =
+                    new ActiveMQConnectionFactory("tcp://localhost:61616");
             conFactory.setTrustAllPackages(true);
             Connection con = conFactory.createConnection();
 


### PR DESCRIPTION
## Summary
- specify the ActiveMQ broker URL in `Validator` to ensure it connects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b970aee308326bcfc204cc2c22337