### PR TITLE
Fix failure reason aggregation

### DIFF
--- a/Example_ActiveMQCamel/Communication/src/de/tuberlin/cit/vs/IntegrationApp.java
+++ b/Example_ActiveMQCamel/Communication/src/de/tuberlin/cit/vs/IntegrationApp.java
@@ -147,9 +147,21 @@ public class IntegrationApp {
             if (oldEx == null) return newEx;
             Order a = oldEx.getIn().getBody(Order.class);
             Order b = newEx.getIn().getBody(Order.class);
+
             boolean ok = a.isValid() && b.isValid();
             a.setValid(ok);
-            a.setValidationResult("COMPLETED");
+
+            if (ok) {
+                a.setValidationResult("COMPLETED");
+            } else {
+                // preserve any failure reason from the system that rejected the order
+                if (!a.isValid() && a.getValidationResult() != null && !a.getValidationResult().isEmpty()) {
+                    a.setValidationResult(a.getValidationResult());
+                } else if (!b.isValid() && b.getValidationResult() != null && !b.getValidationResult().isEmpty()) {
+                    a.setValidationResult(b.getValidationResult());
+                }
+            }
+
             oldEx.getIn().setBody(a);
             return oldEx;
         }


### PR DESCRIPTION
## Summary
- preserve validation failure reasons when aggregating billing and inventory responses

## Testing
- `javac -d Example_ActiveMQCamel/bin -cp "Example_ActiveMQCamel/Example_libs/*" Example_ActiveMQCamel/Shared/src/de/tuberlin/cit/vs/*.java Example_ActiveMQCamel/Communication/src/de/tuberlin/cit/vs/*.java Example_ActiveMQCamel/Validator/src/de/tuberlin/cit/vs/*.java`
- Manual run of JMS components verifying `[INVALID]` output with `BILL_FAIL`

------
https://chatgpt.com/codex/tasks/task_e_687b9a9519448326bdd4ba91936c783b