### PR TITLE
Fix quoting in CallCenter order prompt

### DIFF
--- a/Example_ActiveMQCamel/Communication/src/de/tuberlin/cit/vs/CallCenterOrderSystem.java
+++ b/Example_ActiveMQCamel/Communication/src/de/tuberlin/cit/vs/CallCenterOrderSystem.java
@@ -34,7 +34,7 @@ public class CallCenterOrderSystem {
 
         // read from stdin
         Scanner sc = new Scanner(System.in);
-        System.out.println("CallCenter> enter: FullName, surf, dive, custID or ‘quit’");
+        System.out.println("CallCenter> enter: FullName, surf, dive, custID or 'quit'");
         while (sc.hasNextLine()) {
             String line = sc.nextLine();
             if (line.equalsIgnoreCase("quit")) break;


### PR DESCRIPTION
## Summary
- standardize the 'quit' prompt string in `CallCenterOrderSystem`

## Testing
- `javac Example_ActiveMQCamel/Communication/src/de/tuberlin/cit/vs/CallCenterOrderSystem.java`

------
https://chatgpt.com/codex/tasks/task_e_687b9e7c8b8883269194b29ec20b2190