### PR TITLE
Add JUnit parser tests for Camel example

### DIFF
--- a/Example_ActiveMQCamel/Communication/src/test/java/de/tuberlin/cit/vs/IntegrationAppParserTest.java
+++ b/Example_ActiveMQCamel/Communication/src/test/java/de/tuberlin/cit/vs/IntegrationAppParserTest.java
@@ -1,0 +1,56 @@
+package de.tuberlin.cit.vs;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.DefaultExchange;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.*;
+
+public class IntegrationAppParserTest {
+
+    private Exchange parse(String line) throws Exception {
+        DefaultCamelContext ctx = new DefaultCamelContext();
+        Exchange ex = new DefaultExchange(ctx);
+        ex.getIn().setBody(line);
+        Method m = IntegrationApp.class.getDeclaredMethod("stringToOrder", Exchange.class);
+        m.setAccessible(true);
+        m.invoke(null, ex);
+        return ex;
+    }
+
+    @Test
+    public void parsesWebOrderLine() throws Exception {
+        Exchange ex = parse("c123,John,Doe,2,3");
+        Order o = ex.getIn().getBody(Order.class);
+        assertNotNull(o);
+        assertEquals("c123", o.getCustomerID());
+        assertEquals("John", o.getFirstName());
+        assertEquals("Doe", o.getLastName());
+        assertEquals(2, o.getNumberOfDivingSuits());
+        assertEquals(3, o.getNumberOfSurfboards());
+        assertNull(ex.getProperty("CamelSkipMessage"));
+    }
+
+    @Test
+    public void parsesCallCenterLine() throws Exception {
+        Exchange ex = parse("John Doe,3,2,c123");
+        Order o = ex.getIn().getBody(Order.class);
+        assertNotNull(o);
+        assertEquals("c123", o.getCustomerID());
+        assertEquals("John", o.getFirstName());
+        assertEquals("Doe", o.getLastName());
+        assertEquals(2, o.getNumberOfDivingSuits());
+        assertEquals(3, o.getNumberOfSurfboards());
+        assertNull(ex.getProperty("CamelSkipMessage"));
+    }
+
+    @Test
+    public void rejectsMalformedLine() throws Exception {
+        Exchange ex = parse("bad,line");
+        assertEquals("bad,line", ex.getIn().getBody());
+        assertEquals(Boolean.TRUE, ex.getProperty("CamelSkipMessage"));
+    }
+}

--- a/Example_ActiveMQCamel/build.gradle
+++ b/Example_ActiveMQCamel/build.gradle
@@ -1,0 +1,45 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    flatDir {
+        dirs 'Example_libs', '/opt/gradle/lib'
+    }
+}
+
+dependencies {
+    implementation name: 'camel-core-2.16.3'
+    implementation name: 'camel-jms-2.16.3'
+    implementation name: 'camel-spring-2.16.3'
+    implementation name: 'camel-stream-2.16.3'
+    implementation name: 'activemq-all-5.13.3'
+    implementation name: 'activemq-camel-5.13.3'
+    implementation name: 'slf4j-api-1.6.6'
+    implementation name: 'spring-beans-4.3.0.RELEASE'
+    implementation name: 'spring-context-4.3.0.RELEASE'
+    implementation name: 'jaxb-api-2.3.1'
+    implementation name: 'jaxb-runtime-2.3.1'
+    implementation name: 'commons-pool2-2.4.2'
+
+    testImplementation name: 'junit-4.13.2'
+    testImplementation name: 'hamcrest-core-1.3'
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['Communication/src', 'Shared/src', 'Validator/src']
+            exclude '**/test/**'
+        }
+    }
+    test {
+        java {
+            srcDirs = ['Communication/src/test/java']
+        }
+    }
+}
+
+test {
+    useJUnit()
+}

--- a/Example_ActiveMQCamel/settings.gradle
+++ b/Example_ActiveMQCamel/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'Example_ActiveMQCamel'


### PR DESCRIPTION
## Summary
- add Gradle build to compile Communication and Shared modules
- write IntegrationApp parser unit tests

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687b9e8d784c8326a690fdb743f8446e